### PR TITLE
code coverage

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
             make test
         
         - name: Get Coverage
-          run: sudo docker run -e CODACY_PROJECT_TOKEN=$CODACY_PROJECT_TOKEN -v $PWD:/code codacy/codacy-coverage-reporter:latest report -r result.lcov
+          run: bash <(curl -Ls https://coverage.codacy.com/get.sh) report -r result.lcov
           env:
             CODACY_PROJECT_TOKEN: ${{secrets.CODACY_PROJECT_TOKEN}}
           

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
           run: make test
         
         - name: Get Coverage
-          run: bash <(curl -Ls https://coverage.codacy.com/get.sh)
+          run: bash <(curl -ls https://coverage.codacy.com/get.sh) report -r coverage/report.lcov
           env:
             CODACY_PROJECT_TOKEN: ${{secrets.CODACY_PROJECT_TOKEN}}
           

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,11 +14,10 @@ jobs:
 
         - name: Unit Testing
           run: |
-            mkdir coverage # Make sure folder exists with user permissions for sending the coverage
             make test
         
         - name: Get Coverage
-          run: docker run -e CODACY_PROJECT_TOKEN=$CODACY_PROJECT_TOKEN -v $PWD:/code codacy/codacy-coverage-reporter:latest report -r coverage/result.lcov
+          run: docker run -e CODACY_PROJECT_TOKEN=$CODACY_PROJECT_TOKEN -v $PWD:/code codacy/codacy-coverage-reporter:latest report -r result.lcov
           env:
             CODACY_PROJECT_TOKEN: ${{secrets.CODACY_PROJECT_TOKEN}}
           

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,9 @@ jobs:
           uses: actions/checkout@v2.1.0
 
         - name: Unit Testing
-          run: make test
+          run: |
+            mkdir coverage # Make sure folder exists with user permissions for sending the coverage
+            make test
         
         - name: Get Coverage
           run: docker run -e CODACY_PROJECT_TOKEN=$CODACY_PROJECT_TOKEN -v $PWD:/code codacy/codacy-coverage-reporter:latest report -r coverage/result.lcov

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,3 +14,9 @@ jobs:
 
         - name: Unit Testing
           run: make test
+        
+        - name: Get Coverage
+          run: bash <(curl -Ls https://coverage.codacy.com/get.sh)
+          env:
+            CODACY_PROJECT_TOKEN: ${{secrets.CODACY_PROJECT_TOKEN}}
+          

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,8 @@
 name: Tests
 
 on:
+  push:
+    branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
   workflow_dispatch:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
           run: make test
         
         - name: Get Coverage
-          run: bash <(curl -ls https://coverage.codacy.com/get.sh) report -r coverage/report.lcov
+          run: docker run -e CODACY_PROJECT_TOKEN=$CODACY_PROJECT_TOKEN -v $PWD:/code codacy/codacy-coverage-reporter:latest report -r coverage/result.lcov
           env:
             CODACY_PROJECT_TOKEN: ${{secrets.CODACY_PROJECT_TOKEN}}
           

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
             make test
         
         - name: Get Coverage
-          run: docker run -e CODACY_PROJECT_TOKEN=$CODACY_PROJECT_TOKEN -v $PWD:/code codacy/codacy-coverage-reporter:latest report -r result.lcov
+          run: sudo docker run -e CODACY_PROJECT_TOKEN=$CODACY_PROJECT_TOKEN -v $PWD:/code codacy/codacy-coverage-reporter:latest report -r result.lcov
           env:
             CODACY_PROJECT_TOKEN: ${{secrets.CODACY_PROJECT_TOKEN}}
           

--- a/ProjectAlchemy.CoreTests/ProjectAlchemy.CoreTests.csproj
+++ b/ProjectAlchemy.CoreTests/ProjectAlchemy.CoreTests.csproj
@@ -10,6 +10,10 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <PackageReference Include="coverlet.msbuild" Version="6.0.2">
+          <PrivateAssets>all</PrivateAssets>
+          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0"/>
         <PackageReference Include="NUnit" Version="3.13.3"/>
         <PackageReference Include="NUnit3TestAdapter" Version="4.2.1"/>

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Deploy](https://github.com/senn59/ProjectAlchemy-api/actions/workflows/deploy.yml/badge.svg)](https://github.com/senn59/ProjectAlchemy-api/actions/workflows/deploy.yml) [![Deploy](https://github.com/senn59/ProjectAlchemy-api/actions/workflows/deploy.yml/badge.svg)](https://github.com/senn59/ProjectAlchemy-api/actions/workflows/deploy.yml)
+[![Deploy](https://github.com/senn59/ProjectAlchemy-api/actions/workflows/deploy.yml/badge.svg)](https://github.com/senn59/ProjectAlchemy-api/actions/workflows/deploy.yml) [![Tests](https://github.com/senn59/ProjectAlchemy-api/actions/workflows/test.yml/badge.svg)](https://github.com/senn59/ProjectAlchemy-api/actions/workflows/test.yml)
 # ProjectAlchemy-api
 This is the API for the ProjectAlchemy project, a tool for agile project management. See [ProjectAlchemy-client](https://github.com/senn59/ProjectAlchemy-client) for the frontend.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,4 +12,6 @@
     build:
       context: .
       dockerfile: ProjectAlchemy.CoreTests/Dockerfile
-    command: dotnet test
+    command: dotnet test /p:CollectCoverage=true /p:CoverletOutputFormat=lcov /p:CoverletOutput="/coverage/result.lcov"
+    volumes:
+      - ./coverage:/coverage

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,6 @@
     build:
       context: .
       dockerfile: ProjectAlchemy.CoreTests/Dockerfile
-    command: dotnet test /p:CollectCoverage=true /p:CoverletOutputFormat=lcov /p:CoverletOutput="result.lcov"
+    command: dotnet test /p:CollectCoverage=true /p:CoverletOutputFormat=lcov /p:CoverletOutput="/c/result.lcov"
     volumes:
-      - .:/coverage
+      - .:/c

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,6 @@
     build:
       context: .
       dockerfile: ProjectAlchemy.CoreTests/Dockerfile
-    command: dotnet test /p:CollectCoverage=true /p:CoverletOutputFormat=lcov /p:CoverletOutput="/coverage/result.lcov"
+    command: dotnet test /p:CollectCoverage=true /p:CoverletOutputFormat=lcov /p:CoverletOutput="result.lcov"
     volumes:
-      - ./coverage:/coverage
+      - .:/coverage


### PR DESCRIPTION
send test report to codacy for the coverage, fix an issue with duplicate badge in readme.

I was planning on running the coverage report script from codacy within docker using the provided image but this is not possible without additional virtualization since the runner runs on arm64 so I decided to install Java on the runner instead in order to run the native script since the extra hassle of virtualization is not worth it since there is no major benefit.