### PR TITLE
issue key

### DIFF
--- a/ProjectAlchemy.Core/Dtos/Issue.cs
+++ b/ProjectAlchemy.Core/Dtos/Issue.cs
@@ -6,7 +6,7 @@ namespace ProjectAlchemy.Core.Dtos;
 
 public class Issue
 {
-    public required int Id { get; set; }
+    public required int Key { get; set; }
     [Required(AllowEmptyStrings = false)]
     [StringLength(IssueService.MaxNameLength)]
     public required string Name { get; set; }

--- a/ProjectAlchemy.Core/Dtos/IssueCreate.cs
+++ b/ProjectAlchemy.Core/Dtos/IssueCreate.cs
@@ -10,5 +10,5 @@ public class IssueCreate
     [MaxLength(IssueService.MaxNameLength)]
     public required string Name { get; set; }
     public required IssueType Type { get; set; }
-    public required int LaneId { get; set; }
+    public required string LaneId { get; set; }
 }

--- a/ProjectAlchemy.Core/Dtos/IssuePartial.cs
+++ b/ProjectAlchemy.Core/Dtos/IssuePartial.cs
@@ -4,7 +4,7 @@ namespace ProjectAlchemy.Core.Dtos;
 
 public class IssuePartial
 {
-    public required int Id { get; set; }
+    public required int Key { get; set; }
     public required string Name { get; set; }
     public required IssueType Type { get; set; }
     public required Lane Lane { get; set; }

--- a/ProjectAlchemy.Core/Dtos/Lane.cs
+++ b/ProjectAlchemy.Core/Dtos/Lane.cs
@@ -5,8 +5,8 @@ namespace ProjectAlchemy.Core.Dtos;
 
 public class Lane
 {
-    public int Id { get; set; }
+    public string Id { get; init; } = Guid.NewGuid().ToString();
     [Required(AllowEmptyStrings = false)]
     [StringLength(LaneService.MaxNameLength)]
-    public string Name { get; set; }
+    public required string Name { get; init; }
 }

--- a/ProjectAlchemy.Core/Interfaces/IAuthorizationService.cs
+++ b/ProjectAlchemy.Core/Interfaces/IAuthorizationService.cs
@@ -3,7 +3,7 @@ namespace ProjectAlchemy.Core.Interfaces;
 public interface IAuthorizationService
 {
     Task AuthorizeProjectAccess(string userId, string projectId);
-    Task AuthorizeIssueDeletion(string userId, string projectId, int issueId);
-    Task AuthorizeIssueAccess(string userId, string projectId, int issueId);
-    Task AuthorizeIssueUpdate(string userId, string projectId, int issueId);
+    Task AuthorizeIssueDeletion(string userId, string projectId, int issueKey);
+    Task AuthorizeIssueAccess(string userId, string projectId, int issueKey);
+    Task AuthorizeIssueUpdate(string userId, string projectId, int issueKey);
 }

--- a/ProjectAlchemy.Core/Interfaces/IIssueRepository.cs
+++ b/ProjectAlchemy.Core/Interfaces/IIssueRepository.cs
@@ -4,7 +4,7 @@ namespace ProjectAlchemy.Core.Interfaces;
 
 public interface IIssueRepository
 {
-    public Task<Issue?> GetById(int id);
+    public Task<Issue?> GetById(int issueId, string projectId);
     public Task<IssuePartial> Create(IssueCreate issue, string projectId);
     public Task<Issue> Update(Issue updated, string projectId);
     public Task DeleteById(int id);

--- a/ProjectAlchemy.Core/Interfaces/IIssueRepository.cs
+++ b/ProjectAlchemy.Core/Interfaces/IIssueRepository.cs
@@ -4,8 +4,8 @@ namespace ProjectAlchemy.Core.Interfaces;
 
 public interface IIssueRepository
 {
-    public Task<Issue?> GetById(int issueId, string projectId);
+    public Task<Issue?> GetByKey(int issueKey, string projectId);
     public Task<IssuePartial> Create(IssueCreate issue, string projectId);
     public Task<Issue> Update(Issue updated, string projectId);
-    public Task DeleteById(int id);
+    public Task DeleteByKey(int key, string projectId);
 }

--- a/ProjectAlchemy.Core/Interfaces/ILaneRepository.cs
+++ b/ProjectAlchemy.Core/Interfaces/ILaneRepository.cs
@@ -4,5 +4,5 @@ namespace ProjectAlchemy.Core.Interfaces;
 
 public interface ILaneRepository
 {
-    Task<Lane?> GetLaneById(int laneId, string projectId);
+    Task<Lane?> GetLaneById(string laneId, string projectId);
 }

--- a/ProjectAlchemy.Core/Interfaces/IProjectRepository.cs
+++ b/ProjectAlchemy.Core/Interfaces/IProjectRepository.cs
@@ -7,6 +7,6 @@ public interface IProjectRepository
     public Task<Project?> Get(string id);
     public Task<Project> Create(Project project);
     public Task<bool> HasMember(string projectId, string userId);
-    public Task<bool> HasIssue(string projectId, int issueId);
+    public Task<bool> HasIssue(string projectId, int issueKey);
     public Task<Member?> GetMember(string projectId, string userId);
 }

--- a/ProjectAlchemy.Core/Services/AuthorizationService.cs
+++ b/ProjectAlchemy.Core/Services/AuthorizationService.cs
@@ -17,9 +17,9 @@ public class AuthorizationService(IProjectRepository projectRepository): IAuthor
         }
     }
 
-    public async Task AuthorizeIssueDeletion(string userId, string projectId, int issueId)
+    public async Task AuthorizeIssueDeletion(string userId, string projectId, int issueKey)
     {
-        if (!await projectRepository.HasIssue(projectId, issueId))
+        if (!await projectRepository.HasIssue(projectId, issueKey))
         {
             throw new NotFoundException();
         }
@@ -36,9 +36,9 @@ public class AuthorizationService(IProjectRepository projectRepository): IAuthor
         }
     }
     
-    public async Task AuthorizeIssueAccess(string userId, string projectId, int issueId)
+    public async Task AuthorizeIssueAccess(string userId, string projectId, int issueKey)
     {
-        if (!await projectRepository.HasIssue(projectId, issueId))
+        if (!await projectRepository.HasIssue(projectId, issueKey))
         {
             throw new NotFoundException();
         }
@@ -49,9 +49,9 @@ public class AuthorizationService(IProjectRepository projectRepository): IAuthor
         }
     }
     
-    public async Task AuthorizeIssueUpdate(string userId, string projectId, int issueId)
+    public async Task AuthorizeIssueUpdate(string userId, string projectId, int issueKey)
     {
-        if (!await projectRepository.HasIssue(projectId, issueId))
+        if (!await projectRepository.HasIssue(projectId, issueKey))
         {
             throw new NotFoundException();
         }

--- a/ProjectAlchemy.Core/Services/IssueService.cs
+++ b/ProjectAlchemy.Core/Services/IssueService.cs
@@ -19,7 +19,7 @@ public class IssueService(IIssueRepository issueRepository, IAuthorizationServic
     {
         await authService.AuthorizeIssueAccess(userId, projectId, issueId);
         
-        var issue = await issueRepository.GetById(issueId, projectId);
+        var issue = await issueRepository.GetByKey(issueId, projectId);
         if (issue == null)
         {
             throw new NotFoundException();
@@ -34,9 +34,9 @@ public class IssueService(IIssueRepository issueRepository, IAuthorizationServic
         return await issueRepository.Update(item, projectId);
     }
     
-    public async Task DeleteById(int issueId, string userId, string projectId)
+    public async Task DeleteByKey(int issueKey, string userId, string projectId)
     {
-        await authService.AuthorizeIssueDeletion(userId, projectId, issueId);
-        await issueRepository.DeleteById(issueId);
+        await authService.AuthorizeIssueDeletion(userId, projectId, issueKey);
+        await issueRepository.DeleteByKey(issueKey, projectId);
     }
 }

--- a/ProjectAlchemy.Core/Services/IssueService.cs
+++ b/ProjectAlchemy.Core/Services/IssueService.cs
@@ -15,11 +15,11 @@ public class IssueService(IIssueRepository issueRepository, IAuthorizationServic
         return await issueRepository.Create(issue, projectId);
     }
 
-    public async Task<Issue> GetById(int issueId, string userId, string projectId )
+    public async Task<Issue> GetByKey(int issueKey, string userId, string projectId )
     {
-        await authService.AuthorizeIssueAccess(userId, projectId, issueId);
+        await authService.AuthorizeIssueAccess(userId, projectId, issueKey);
         
-        var issue = await issueRepository.GetByKey(issueId, projectId);
+        var issue = await issueRepository.GetByKey(issueKey, projectId);
         if (issue == null)
         {
             throw new NotFoundException();
@@ -30,7 +30,7 @@ public class IssueService(IIssueRepository issueRepository, IAuthorizationServic
 
     public async Task<Issue> Update(Issue item, string userId, string projectId)
     {
-        await authService.AuthorizeIssueUpdate(userId, projectId, item.Id);
+        await authService.AuthorizeIssueUpdate(userId, projectId, item.Key);
         return await issueRepository.Update(item, projectId);
     }
     

--- a/ProjectAlchemy.Core/Services/IssueService.cs
+++ b/ProjectAlchemy.Core/Services/IssueService.cs
@@ -19,7 +19,7 @@ public class IssueService(IIssueRepository issueRepository, IAuthorizationServic
     {
         await authService.AuthorizeIssueAccess(userId, projectId, issueId);
         
-        var issue = await issueRepository.GetById(issueId);
+        var issue = await issueRepository.GetById(issueId, projectId);
         if (issue == null)
         {
             throw new NotFoundException();

--- a/ProjectAlchemy.Core/Services/LaneService.cs
+++ b/ProjectAlchemy.Core/Services/LaneService.cs
@@ -7,9 +7,18 @@ namespace ProjectAlchemy.Core.Services;
 public class LaneService(ILaneRepository laneRepository, IAuthorizationService authService)
 {
     public const int MaxNameLength = 20;
-    public async Task<Lane> GetById(int laneId, string projectId, string userId)
+    public async Task<Lane> GetById(string laneId, string projectId, string userId)
     {
         await authService.AuthorizeProjectAccess(userId, projectId);
         return await laneRepository.GetLaneById(laneId, projectId) ?? throw new NotFoundException("Not a valid lane in project");
+    }
+    
+    public static IReadOnlyList<Lane> GetDefaultLanes() //ensure Id's are unique
+    {
+        return  [
+            new Lane { Name = "To do" },
+            new Lane { Name = "In progress" },
+            new Lane { Name = "Done" }
+        ];
     }
 }

--- a/ProjectAlchemy.Core/Services/ProjectService.cs
+++ b/ProjectAlchemy.Core/Services/ProjectService.cs
@@ -8,11 +8,6 @@ namespace ProjectAlchemy.Core.Services;
 public class ProjectService(IProjectRepository repository, IAuthorizationService authService)
 {
     public const int MaxNameLength = 30;
-    private readonly IReadOnlyList<Lane> _defaultLanes = [
-        new() { Name = "To do" },
-        new() { Name = "In progress" },
-        new() { Name = "Done" }
-    ];
 
     public async Task<Project> Get(string projectId, string userid)
     {
@@ -39,7 +34,7 @@ public class ProjectService(IProjectRepository repository, IAuthorizationService
             Id = Guid.NewGuid().ToString(),
             Name = projectName,
             Issues = [],
-            Lanes = _defaultLanes,
+            Lanes = LaneService.GetDefaultLanes(),
             Members = [creator]
         };
         

--- a/ProjectAlchemy.Persistence/AppDbContext.cs
+++ b/ProjectAlchemy.Persistence/AppDbContext.cs
@@ -17,6 +17,9 @@ public class AppDbContext(DbContextOptions<AppDbContext> options) : DbContext(op
         modelBuilder.Entity<IssueEntity>()
             .Property(p => p.Id)
             .ValueGeneratedOnAdd();
+        modelBuilder.Entity<IssueEntity>()
+            .Property(p => p.Deleted)
+            .HasDefaultValue(false);
         modelBuilder.Entity<LaneEntity>()
             .Property(p => p.Id)
             .ValueGeneratedOnAdd();

--- a/ProjectAlchemy.Persistence/Entities/IssueEntity.cs
+++ b/ProjectAlchemy.Persistence/Entities/IssueEntity.cs
@@ -10,7 +10,7 @@ namespace ProjectAlchemy.Persistence.Entities;
 public class IssueEntity
 {
     [Required]
-    public int Id { get; init; }
+    public int Id { get; set; }
     [Required]
     public int Key { get; set; }
     [Required]

--- a/ProjectAlchemy.Persistence/Entities/IssueEntity.cs
+++ b/ProjectAlchemy.Persistence/Entities/IssueEntity.cs
@@ -33,7 +33,7 @@ public class IssueEntity
     {
         return new Issue
         {
-            Id = entity.Key,
+            Key = entity.Key,
             Description = entity.Description,
             Lane = lane,
             Name = entity.Name,
@@ -45,7 +45,7 @@ public class IssueEntity
     {
         return new IssueEntity
         {
-            Key = issue.Id,
+            Key = issue.Key,
             Name = issue.Name,
             Description = issue.Description,
             Type = issue.Type,
@@ -67,7 +67,7 @@ public class IssueEntity
     {
         return new IssuePartial
         {
-            Id = entity.Key,
+            Key = entity.Key,
             Lane = lane,
             Name = entity.Name,
             Type = entity.Type
@@ -78,7 +78,7 @@ public class IssueEntity
     {
         return new IssueEntity
         {
-            Key = partial.Id,
+            Key = partial.Key,
             Name = partial.Name,
             LaneId = partial.Lane.Id,
             Type = partial.Type

--- a/ProjectAlchemy.Persistence/Entities/IssueEntity.cs
+++ b/ProjectAlchemy.Persistence/Entities/IssueEntity.cs
@@ -24,7 +24,8 @@ public class IssueEntity
     [Required]
     public bool Deleted { get; set; }
         
-    public int LaneId { get; init; }
+    [MaxLength(36)]
+    public string LaneId { get; init; }
     [MaxLength(36)]
     public string? ProjectId { get; set; }
     public ProjectEntity? Project { get; init; }

--- a/ProjectAlchemy.Persistence/Entities/IssueEntity.cs
+++ b/ProjectAlchemy.Persistence/Entities/IssueEntity.cs
@@ -18,9 +18,10 @@ public class IssueEntity
     [MaxLength(IssueService.MaxDescriptionLength)]
     public string Description { get; init; } = "";
     public IssueType Type { get; init; }
+    public bool Deleted { get; set; }
+        
     public int LaneId { get; init; }
-    
-    [MaxLength(200)]
+    [MaxLength(36)]
     public string? ProjectId { get; set; }
     public ProjectEntity? Project { get; init; }
 

--- a/ProjectAlchemy.Persistence/Entities/IssueEntity.cs
+++ b/ProjectAlchemy.Persistence/Entities/IssueEntity.cs
@@ -12,12 +12,16 @@ public class IssueEntity
     [Required]
     public int Id { get; init; }
     [Required]
+    public int Key { get; set; }
+    [Required]
     [StringLength(IssueService.MaxNameLength, MinimumLength = 1)]
     public required string Name { get; init; }
     [Required]
     [MaxLength(IssueService.MaxDescriptionLength)]
     public string Description { get; init; } = "";
-    public IssueType Type { get; init; }
+    [Required]
+    public required IssueType Type { get; init; }
+    [Required]
     public bool Deleted { get; set; }
         
     public int LaneId { get; init; }
@@ -29,7 +33,7 @@ public class IssueEntity
     {
         return new Issue
         {
-            Id = entity.Id,
+            Id = entity.Key,
             Description = entity.Description,
             Lane = lane,
             Name = entity.Name,
@@ -41,7 +45,7 @@ public class IssueEntity
     {
         return new IssueEntity
         {
-            Id = issue.Id,
+            Key = issue.Id,
             Name = issue.Name,
             Description = issue.Description,
             Type = issue.Type,
@@ -63,7 +67,7 @@ public class IssueEntity
     {
         return new IssuePartial
         {
-            Id = entity.Id,
+            Id = entity.Key,
             Lane = lane,
             Name = entity.Name,
             Type = entity.Type
@@ -74,7 +78,7 @@ public class IssueEntity
     {
         return new IssueEntity
         {
-            Id = partial.Id,
+            Key = partial.Id,
             Name = partial.Name,
             LaneId = partial.Lane.Id,
             Type = partial.Type

--- a/ProjectAlchemy.Persistence/Entities/LaneEntity.cs
+++ b/ProjectAlchemy.Persistence/Entities/LaneEntity.cs
@@ -7,7 +7,8 @@ namespace ProjectAlchemy.Persistence.Entities;
 public class LaneEntity
 {
     [Required]
-    public required int Id { get; init; }
+    [MaxLength(36)]
+    public required string Id { get; init; }
     [MaxLength(LaneService.MaxNameLength)]
     public required string Name { get; init; }
     

--- a/ProjectAlchemy.Persistence/Repositories/IssueRepository.cs
+++ b/ProjectAlchemy.Persistence/Repositories/IssueRepository.cs
@@ -39,6 +39,8 @@ public class IssueRepository: IIssueRepository
     public async Task<Issue> Update(Issue updated, string projectId)
     {
         var entity = IssueEntity.FromIssue(updated);
+        var id = _context.Issues.FirstAsync(i => i.Key == updated.Id && i.ProjectId == projectId).Result.Id;
+        entity.Id = id;
         entity.ProjectId = projectId;
         _context.ChangeTracker.Clear();
         _context.Update(entity);

--- a/ProjectAlchemy.Persistence/Repositories/IssueRepository.cs
+++ b/ProjectAlchemy.Persistence/Repositories/IssueRepository.cs
@@ -39,7 +39,7 @@ public class IssueRepository: IIssueRepository
     public async Task<Issue> Update(Issue updated, string projectId)
     {
         var entity = IssueEntity.FromIssue(updated);
-        var id = _context.Issues.FirstAsync(i => i.Key == updated.Id && i.ProjectId == projectId).Result.Id;
+        var id = _context.Issues.FirstAsync(i => i.Key == updated.Key && i.ProjectId == projectId).Result.Id;
         entity.Id = id;
         entity.ProjectId = projectId;
         _context.ChangeTracker.Clear();

--- a/ProjectAlchemy.Persistence/Repositories/IssueRepository.cs
+++ b/ProjectAlchemy.Persistence/Repositories/IssueRepository.cs
@@ -14,9 +14,9 @@ public class IssueRepository: IIssueRepository
         _context = context;
     }
 
-    public async Task<Issue?> GetById(int issueId, string projectId)
+    public async Task<Issue?> GetByKey(int issueKey, string projectId)
     {
-        var issue = await _context.Issues.FirstOrDefaultAsync(i => i.Id == issueId && i.ProjectId == projectId);
+        var issue = await _context.Issues.FirstOrDefaultAsync(i => i.Key == issueKey && i.ProjectId == projectId);
         if (issue == null || issue.Deleted)
         {
             return null;
@@ -29,6 +29,7 @@ public class IssueRepository: IIssueRepository
     {
         var entity = IssueEntity.FromIssueCreate(issue);
         entity.ProjectId = projectId;
+        entity.Key = await _context.Issues.CountAsync(i => i.ProjectId == projectId) + 1;
         await _context.Issues.AddAsync(entity);
         await _context.SaveChangesAsync();
         var lane = await _context.Lanes.FindAsync(entity.LaneId);
@@ -50,9 +51,9 @@ public class IssueRepository: IIssueRepository
         return IssueEntity.ToIssue(entity, LaneEntity.ToLane(lane!));
     }
 
-    public async Task DeleteById(int id)
+    public async Task DeleteByKey(int key, string projectId)
     {
-        var issue = await _context.Issues.FindAsync(id);
+        var issue = await _context.Issues.FirstOrDefaultAsync(i => i.ProjectId == projectId && i.Key == key);
         if (issue != null)
         {
             issue.Deleted = true;

--- a/ProjectAlchemy.Persistence/Repositories/LaneRepository.cs
+++ b/ProjectAlchemy.Persistence/Repositories/LaneRepository.cs
@@ -14,7 +14,7 @@ public class LaneRepository: ILaneRepository
         _context = context;
     }
     
-    public async Task<Lane?> GetLaneById(int laneId, string projectId)
+    public async Task<Lane?> GetLaneById(string laneId, string projectId)
     {
         var entity = await _context.Lanes.FirstOrDefaultAsync(l => l.Id == laneId && l.ProjectId == projectId);
         return entity == null ? null : LaneEntity.ToLane(entity);

--- a/ProjectAlchemy.Persistence/Repositories/ProjectRepository.cs
+++ b/ProjectAlchemy.Persistence/Repositories/ProjectRepository.cs
@@ -18,7 +18,7 @@ public class ProjectRepository: IProjectRepository
     {
         var project = await _context.Projects
             .Include(p => p.Members)
-            .Include(p => p.Issues)
+            .Include(p => p.Issues.Where(i => !i.Deleted))
             .Include(p => p.Lanes)
             .FirstOrDefaultAsync(p => p.Id == id);
         return project == null ? null : ProjectEntity.ToProject(project);
@@ -39,7 +39,7 @@ public class ProjectRepository: IProjectRepository
 
     public async Task<bool> HasIssue(string projectId, int issueId)
     {
-        return await _context.Issues.AnyAsync(i => i.ProjectId == projectId && i.Id == issueId); 
+        return await _context.Issues.AnyAsync(i => i.ProjectId == projectId && i.Id == issueId && !i.Deleted); 
     }
 
     public async Task<Member?> GetMember(string projectId, string userId)

--- a/ProjectAlchemy.Persistence/Repositories/ProjectRepository.cs
+++ b/ProjectAlchemy.Persistence/Repositories/ProjectRepository.cs
@@ -37,9 +37,9 @@ public class ProjectRepository: IProjectRepository
         return await _context.Members.AnyAsync(m => m.ProjectId == projectId && m.UserId == userId);
     }
 
-    public async Task<bool> HasIssue(string projectId, int issueId)
+    public async Task<bool> HasIssue(string projectId, int issueKey)
     {
-        return await _context.Issues.AnyAsync(i => i.ProjectId == projectId && i.Id == issueId && !i.Deleted); 
+        return await _context.Issues.AnyAsync(i => i.ProjectId == projectId && i.Key == issueKey && !i.Deleted); 
     }
 
     public async Task<Member?> GetMember(string projectId, string userId)

--- a/ProjectAlchemy.Tests/Integration/IssueServiceTests.cs
+++ b/ProjectAlchemy.Tests/Integration/IssueServiceTests.cs
@@ -72,7 +72,7 @@ public class IssueServiceTests: IDisposable
         };
         var created = await _issueService.Create(issue, UserId, _project.Id);
         
-        var action = () => _issueService.DeleteById(9999, UserId, _project.Id);
+        var action = () => _issueService.DeleteByKey(9999, UserId, _project.Id);
 
         created.Id.Should().NotBe(9999);
         await action.Should().ThrowAsync<NotFoundException>();
@@ -88,7 +88,7 @@ public class IssueServiceTests: IDisposable
             LaneId = _project.Lanes.First().Id
         };
         var created = await _issueService.Create(issue, UserId, _project.Id);
-        await _issueService.DeleteById(created.Id, UserId, _project.Id);
+        await _issueService.DeleteByKey(created.Id, UserId, _project.Id);
         
         var action = () => _issueService.GetById(created.Id, UserId, _project.Id);
         

--- a/ProjectAlchemy.Tests/Integration/IssueServiceTests.cs
+++ b/ProjectAlchemy.Tests/Integration/IssueServiceTests.cs
@@ -54,7 +54,7 @@ public class IssueServiceTests: IDisposable
         };
         
         var created = await _issueService.Create(issue, UserId, _project.Id);
-        var retrieved = await _issueService.GetById(created.Id, UserId, _project.Id);
+        var retrieved = await _issueService.GetByKey(created.Key, UserId, _project.Id);
 
         created.Name.Should().BeEquivalentTo(issue.Name);
         created.Type.Should().HaveSameValueAs(issue.Type);
@@ -74,7 +74,7 @@ public class IssueServiceTests: IDisposable
         
         var action = () => _issueService.DeleteByKey(9999, UserId, _project.Id);
 
-        created.Id.Should().NotBe(9999);
+        created.Key.Should().NotBe(9999);
         await action.Should().ThrowAsync<NotFoundException>();
     }
     
@@ -88,9 +88,9 @@ public class IssueServiceTests: IDisposable
             LaneId = _project.Lanes.First().Id
         };
         var created = await _issueService.Create(issue, UserId, _project.Id);
-        await _issueService.DeleteByKey(created.Id, UserId, _project.Id);
+        await _issueService.DeleteByKey(created.Key, UserId, _project.Id);
         
-        var action = () => _issueService.GetById(created.Id, UserId, _project.Id);
+        var action = () => _issueService.GetByKey(created.Key, UserId, _project.Id);
         
         await action.Should().ThrowAsync<NotFoundException>();
     }
@@ -105,7 +105,7 @@ public class IssueServiceTests: IDisposable
             LaneId = _project.Lanes.First().Id
         };
         var created = await _issueService.Create(issue, UserId, _project.Id);
-        var retrieved = await _issueService.GetById(created.Id, UserId, _project.Id);
+        var retrieved = await _issueService.GetByKey(created.Key, UserId, _project.Id);
 
         retrieved.Name = "nottest";
         retrieved.Description = "not empty";

--- a/ProjectAlchemy.Tests/Unit/LaneServiceTests.cs
+++ b/ProjectAlchemy.Tests/Unit/LaneServiceTests.cs
@@ -1,0 +1,26 @@
+using FluentAssertions;
+using ProjectAlchemy.Core.Services;
+
+namespace ProjectAlchemy.Tests.Unit;
+
+public class LaneServiceTests
+{
+    [Fact]
+    public void CreatingDefaultLanesSucceedsWithUniqueItems()
+    {
+        var lanes = LaneService.GetDefaultLanes();
+        var ids = lanes.Select(l => l.Id);
+        var names = lanes.Select(l => l.Name);
+        ids.Should().OnlyHaveUniqueItems();
+        names.Should().OnlyHaveUniqueItems();
+    }
+    
+    [Fact]
+    public void CreatingDefaultLanesMultipleTimesAlwaysEnsuresIdsAreUnique()
+    {
+        var lanes = LaneService.GetDefaultLanes().ToList();
+        lanes.AddRange(LaneService.GetDefaultLanes());
+        lanes.AddRange(LaneService.GetDefaultLanes());
+        lanes.Should().OnlyHaveUniqueItems();
+    }
+}

--- a/ProjectAlchemy.Web/Controllers/IssueController.cs
+++ b/ProjectAlchemy.Web/Controllers/IssueController.cs
@@ -16,7 +16,7 @@ public class IssueController(IssueService issueService) : ControllerBase
     public async Task<Issue> Get(string projectId, int id)
     {
         var userId = JwtHelper.GetId(User);
-        var issue =  await issueService.GetById(id, userId, projectId);
+        var issue = await issueService.GetById(id, userId, projectId);
         return issue;
     }
 

--- a/ProjectAlchemy.Web/Controllers/IssueController.cs
+++ b/ProjectAlchemy.Web/Controllers/IssueController.cs
@@ -12,11 +12,11 @@ namespace ProjectAlchemy.Web.Controllers;
 [Route("api/projects/{projectId}/issues")]
 public class IssueController(IssueService issueService) : ControllerBase
 {
-    [HttpGet("{id:int}")]
-    public async Task<Issue> Get(string projectId, int id)
+    [HttpGet("{key:int}")]
+    public async Task<Issue> Get(string projectId, int key)
     {
         var userId = JwtHelper.GetId(User);
-        var issue = await issueService.GetById(id, userId, projectId);
+        var issue = await issueService.GetByKey(key, userId, projectId);
         return issue;
     }
 
@@ -27,11 +27,11 @@ public class IssueController(IssueService issueService) : ControllerBase
         return await issueService.Create(request, userId, projectId);
     }
     
-    [HttpPatch("{id:int}")]
-    public async Task<Issue> Patch([FromBody] JsonPatchDocument<IssuePatch> patchDoc, int id, string projectId)
+    [HttpPatch("{key:int}")]
+    public async Task<Issue> Patch([FromBody] JsonPatchDocument<IssuePatch> patchDoc, int key, string projectId)
     {
         var userId = JwtHelper.GetId(User); 
-        var issue = await issueService.GetById(id, userId, projectId);
+        var issue = await issueService.GetByKey(key, userId, projectId);
         
         var issuePatch = new IssuePatch()
         {
@@ -51,10 +51,10 @@ public class IssueController(IssueService issueService) : ControllerBase
         return await issueService.Update(issue, userId, projectId);
     }
     
-    [HttpDelete("{id:int}")]
-    public async Task Delete(int id, string projectId)
+    [HttpDelete("{key:int}")]
+    public async Task Delete(int key, string projectId)
     {
         var userId = JwtHelper.GetId(User);
-        await issueService.DeleteByKey(id, userId, projectId);
+        await issueService.DeleteByKey(key, userId, projectId);
     }
 }

--- a/ProjectAlchemy.Web/Controllers/IssueController.cs
+++ b/ProjectAlchemy.Web/Controllers/IssueController.cs
@@ -55,6 +55,6 @@ public class IssueController(IssueService issueService) : ControllerBase
     public async Task Delete(int id, string projectId)
     {
         var userId = JwtHelper.GetId(User);
-        await issueService.DeleteById(id, userId, projectId);
+        await issueService.DeleteByKey(id, userId, projectId);
     }
 }

--- a/ProjectAlchemy.Web/ProjectAlchemy.Web.csproj
+++ b/ProjectAlchemy.Web/ProjectAlchemy.Web.csproj
@@ -10,6 +10,10 @@
     <ItemGroup>
         <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.11" />
         <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.10" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.8">
+          <PrivateAssets>all</PrivateAssets>
+          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
         <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0"/>
         <PackageReference Include="Swashbuckle.AspNetCore.Newtonsoft" Version="7.2.0" />
     </ItemGroup>


### PR DESCRIPTION
Instead of using the autoincrement id for issues we now use a manually created id based on the project to ensure better security and better usability as each project's issue ids will begin at 1.

Furthermore we also changed the lane id to not be an autoincrement id but a GUID also for better security as people wont be able to guess the Id of lanes in other projects